### PR TITLE
Support windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 *.ptx
 *.so
+
+# Windows
+libwrapcuda.dll
+libwrapcuda.exp
+libwrapcuda.lib

--- a/deps/Windows.mk
+++ b/deps/Windows.mk
@@ -1,0 +1,11 @@
+default: libwrapcuda.dll utils.ptx
+
+libwrapcuda.dll: wrapcuda.c
+    nvcc --shared --compiler-options="/wd4819" --linker-options= wrapcuda.c -o libwrapcuda.dll
+
+utils.ptx: utils.cu
+    nvcc -ptx --compiler-options="/wd4819" -gencode=arch=compute_20,code=sm_20 utils.cu
+
+clean:
+    del /Q libwrapcuda.dll libwrapcuda.lib libwrapcuda.exp
+    del /Q utils.ptx

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,4 +1,34 @@
-run(`make`)
-cd("../test") do
-    run(`make`)
-end
+@windows? (
+    begin
+        if haskey(ENV, "VS120COMNTOOLS")
+            vs_cmd_prompt = string(ENV["VS120COMNTOOLS"], "..\\..\\VC\\vcvarsall.bat")
+        elseif haskey(ENV, "VS110COMNTOOLS")
+            vs_cmd_prompt = string(ENV["VS110COMNTOOLS"], "..\\..\\VC\\vcvarsall.bat")
+        elseif haskey(ENV, "VS100COMNTOOLS")
+            vs_cmd_prompt = string(ENV["VS100COMNTOOLS"], "..\\..\\VC\\vcvarsall.bat")
+        else
+            error("Cannot find proper Visual Studio installation. VS 2013, 2012, or 2010 is required.")
+        end
+
+        # check whether 32 or 64 bit archtecture
+        # NOTE: Actually, nvcc in x86 visual studio command prompt doesn't make 32-bit binary
+        #       It depends on whether CUDA toolkit is 32bit or 64bit
+        if Int == Int64
+            arch = "amd64"
+        else
+            arch = "x86"
+        end
+
+        # Run nmake -f Windows.mk under visual studio command prompt
+        run(`cmd /C "$vs_cmd_prompt" $arch & nmake -f Windows.mk`)
+        cd("../test") do
+            run(`cmd /C "$vs_cmd_prompt" $arch & nmake -f Windows.mk`)
+        end
+    end
+    : # for linux or mac
+    begin
+        run(`make`)
+        cd("../test") do
+            run(`make`)
+        end
+    end)

--- a/deps/wrapcuda.c
+++ b/deps/wrapcuda.c
@@ -3,7 +3,13 @@
 #include <cuda_runtime_api.h>
 #include <stdio.h>
 
-cudaError_t wrapcudaMalloc3D(struct cudaPitchedPtr *p, struct cudaExtent *ext)
+#ifdef _WIN32
+#define DLLEXPORT __declspec(dllexport)
+#else
+#define DLLEXPORT
+#endif
+
+DLLEXPORT cudaError_t wrapcudaMalloc3D(struct cudaPitchedPtr *p, struct cudaExtent *ext)
 {
   cudaError_t err;
 /*  printf("width = %d\n", ext->width);
@@ -20,7 +26,7 @@ cudaError_t wrapcudaMalloc3D(struct cudaPitchedPtr *p, struct cudaExtent *ext)
   return err;
 }
 
-cudaError_t wrapcudaMemset3D(struct cudaPitchedPtr *p, char val, struct cudaExtent *ext)
+DLLEXPORT cudaError_t wrapcudaMemset3D(struct cudaPitchedPtr *p, char val, struct cudaExtent *ext)
 {
   return cudaMemset3D(*p, (int) val, *ext);
 }

--- a/src/CUDArt.jl
+++ b/src/CUDArt.jl
@@ -28,7 +28,15 @@ import .CUDArt_gen
 const rt = CUDArt_gen
 
 # To load PTX code, we also need access to the driver API module utilities
-const libcuda = find_library(["libcuda"], ["/usr/lib/"])
+@windows? (
+begin
+    const libcuda = find_library(["nvcuda"], [""])
+end
+: # linux or mac
+begin
+    const libcuda = find_library(["libcuda"], ["/usr/lib/"])
+end)
+
 if isempty(libcuda)
     error("CUDA driver API library cannot be found")
 end

--- a/src/libcudart-6.5.jl
+++ b/src/libcudart-6.5.jl
@@ -20,7 +20,16 @@ include("../gen-6.5/gen_libcudart_h.jl")
 
 typealias cudaError_t cudaError
 
-const libcudart = find_library(["libcudart", "cudart"], ["/usr/local/cuda-6.5/lib", "/usr/local/cuda-6.5/lib64", "/usr/local/cuda/lib", "/usr/local/cuda/lib64"])
+@windows? (
+begin
+    const dllname = (Int == Int64) ? "cudart64_65" : "cudart32_65"
+    const libcudart = find_library([dllname], [string(ENV["CUDA_PATH_V6_5"], "\\bin")])
+end
+: # linux or mac
+begin
+    const libcudart = find_library(["libcudart", "cudart"], ["/usr/local/cuda-6.5/lib", "/usr/local/cuda-6.5/lib64", "/usr/local/cuda/lib", "/usr/local/cuda/lib64"])
+end)
+
 if isempty(libcudart)
     error("CUDA runtime API library cannot be found")
 end

--- a/test/Windows.mk
+++ b/test/Windows.mk
@@ -1,0 +1,7 @@
+default: vadd.ptx
+
+vadd.ptx: vadd.cu
+    nvcc -ptx --compiler-options="/wd4819" vadd.cu
+
+clean:
+    del /Q vadd.ptx


### PR DESCRIPTION
PR for #1 (Merged in single commit)

- Tested in CUDA 6.5 64 bit, Visual Studio 2012/2013. 
- Test is not broken in linux systems but I couldn't test in mac. 

And here is more comments for user. 

- Visual Studio installation is required to use nvcc. 
- Visual Studio 2010/2012/2013 is supported. (These versions are supported in CUDA 6.5) I'm not sure if it works with Visual Studio Express Edition. 
- If you use 32-bit julia build, you have to use 32-bit version of CUDA Toolkit. 