### PR TITLE
Minor fixes to finalizers, device_reset and error handling.

### DIFF
--- a/src/device.jl
+++ b/src/device.jl
@@ -24,11 +24,15 @@ function device_reset(dev::Integer)
             try
                 finalize(p)
             catch ex
-                ## Make sure previous async errors do not prevent
-                ## all finalizers from running
-                warn("Error in finalize($p) ignored: $ex")
-                ## Reset CUDA errors
-                CUDArt.rt.cudaGetLastError()
+                if isa(ex, CudaError) || isa(ex, CudaDriverError)
+                    ## Make sure previous async errors do not prevent
+                    ## all finalizers from running
+                    warn("Error in finalize($p) ignored: $ex")
+                    ## Reset CUDA errors
+                    CUDArt.rt.cudaGetLastError()
+                else
+                    rethrow(ex)
+                end
             end
             push!(todelete, p)
         end

--- a/src/execute.jl
+++ b/src/execute.jl
@@ -1,6 +1,9 @@
 cubox(p::CudaPtr) = cubox(p.ptr)
 cubox(a::CdArray) = cubox(rawpointer(a))
-cubox{T}(x::T) = T[x]
+function cubox{T}(x::T)
+    isbits(T) || error("Kernel argument must be a bits type")
+    T[x]
+end
 
 function launch(f::CuFunction, grid::CudaDims, block::CudaDims, args::Tuple; shmem_bytes::Int=4, stream=null_stream)
     gx = get_dim_x(grid)

--- a/src/libcudart-6.5.jl
+++ b/src/libcudart-6.5.jl
@@ -13,6 +13,7 @@ function checkerror(code::Cuint)
     # let's show a backtrace here
     warn("CUDA error triggered from:")
     Base.show_backtrace(STDOUT, backtrace())
+    println()
     throw(bytestring(cudaGetErrorString(code)))
 end
 
@@ -26,8 +27,8 @@ begin
     # ex: C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v6.5\bin
     # (by default, it is done by CUDA toolkit installer)
 
-    const dllnames = (WORD_SIZE==64) ? 
-        ["cudart64_70", "cudart64_65", "cudart64_60", "cudart64_55", "cudart64_50", "cudart64_50_35"] : 
+    const dllnames = (WORD_SIZE==64) ?
+        ["cudart64_70", "cudart64_65", "cudart64_60", "cudart64_55", "cudart64_50", "cudart64_50_35"] :
         ["cudart32_70", "cudart32_65", "cudart32_60", "cudart32_55", "cudart32_50", "cudart32_50_35"]
     const libcudart = find_library(dllnames, [""])
 end

--- a/src/libcudart-6.5.jl
+++ b/src/libcudart-6.5.jl
@@ -14,7 +14,7 @@ function checkerror(code::Cuint)
     warn("CUDA error triggered from:")
     Base.show_backtrace(STDOUT, backtrace())
     println()
-    throw(bytestring(cudaGetErrorString(code)))
+    throw(CudaError(code))
 end
 
 include("../gen-6.5/gen_libcudart_h.jl")

--- a/src/module.jl
+++ b/src/module.jl
@@ -3,7 +3,7 @@
 
 function checkdrv(code::Integer)
     if code != 0
-        error(driver_error_descriptions[int(code)])
+        throw(CudaDriverError(code))
     end
     nothing
 end
@@ -11,7 +11,7 @@ end
 function checkdrv(code::Integer, msg::String)
     if code != 0
         warn(msg)
-        error(driver_error_descriptions[int(code)])
+        throw(CudaDriverError(code))
     end
     nothing
 end
@@ -48,7 +48,11 @@ function unload(md::CuModule)
     try
         checkdrv(ccall((:cuModuleUnload, libcuda), Cint, (Ptr{Void},), md.handle))
     catch ex
-        warn("unload($md) failed, error ignored: $ex")
+        if isa(ex, CudaError) || isa(ex, CudaDriverError)
+            warn("unload($md) failed, error ignored: $ex")
+        else
+            rethrow(ex)
+        end
     end
 end
 

--- a/src/module.jl
+++ b/src/module.jl
@@ -44,7 +44,12 @@ function CuModule(f::Function, filename::ASCIIString)
 end
 
 function unload(md::CuModule)
-    checkdrv(ccall((:cuModuleUnload, libcuda), Cint, (Ptr{Void},), md.handle))
+    ## This is used as a finalizer, so ignore all errors
+    try
+        checkdrv(ccall((:cuModuleUnload, libcuda), Cint, (Ptr{Void},), md.handle))
+    catch ex
+        warn("unload($md) failed, error ignored: $ex")
+    end
 end
 
 immutable CuFunction


### PR DESCRIPTION
Related to #17.

Main changes:
- Use CudaError and CudaDriverError instead of plain error(message-string)
- When running finalizers, ignore all errors so that other finalizing code still executes (see #17)
- Force device initialization by allocating 0 bytes not 1 (efficiency!, also no need to call free)
- Restrict launch arguments to bits types, because others are not handled at all, and likely need StrPack support do get correct structure layout (e.g., float4 must be aligned to 16 bytes, etc.). So it's best to forbid unsupported types completely for now.

What's your opinion on StrPack? There should be a "julian" way of passing arbitrary composite types to cuda. (Related: #14)
