### PR TITLE
Weakrefs

### DIFF
--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -178,7 +178,7 @@ function CudaPitchedArray(T::Type, dims::Dims)
     pp = rt.cudaPitchedPtr(pp, dims[1]) # correct the xsize
     cptr = pp.ptr
     dev = device()
-    cuda_ptrs[cptr] = dev
+    cuda_ptrs[WeakRef(cptr)] = dev
     g = CudaPitchedArray{T,length(dims)}(pp, dims, dev)
     finalizer(g, free)
     g
@@ -376,7 +376,7 @@ function HostArray{T}(::Type{T}, sz::Dims; flags::Integer=rt.cudaHostAllocDefaul
     data = pointer_to_array(convert(Ptr{T}, ptr), sz, false)
     ha = HostArray(ptr, data)
     finalizer(ha, free)
-    cuda_ptrs[ptr] = device()
+    cuda_ptrs[WeakRef(ptr)] = device()
     ha
 end
 

--- a/src/module.jl
+++ b/src/module.jl
@@ -19,7 +19,7 @@ end
 immutable CuModule
     handle::Ptr{Void}
 
-    function CuModule(filename::ASCIIString, finalize::Bool = true)
+    function CuModule(filename::String, finalize::Bool = true)
         a = Array(Ptr{Void}, 1)
         checkdrv(ccall((:cuModuleLoad, libcuda), Cint, (Ptr{Ptr{Void}}, Ptr{Cchar}), a, filename), filename)
         md = new(a[1])
@@ -32,7 +32,7 @@ immutable CuModule
 end
 
 # do syntax, f(module)
-function CuModule(f::Function, filename::ASCIIString)
+function CuModule(f::Function, filename::String)
     md = CuModule(filename, false)
     local ret
     try
@@ -50,7 +50,7 @@ end
 immutable CuFunction
     handle::Ptr{Void}
 
-    function CuFunction(md::CuModule, name::ASCIIString)
+    function CuFunction(md::CuModule, name::String)
         a = Array(Ptr{Void}, 1)
         checkdrv(ccall((:cuModuleGetFunction, libcuda), Cint,
                        (Ptr{Ptr{Void}}, Ptr{Void}, Ptr{Cchar}),
@@ -59,7 +59,7 @@ immutable CuFunction
     end
 end
 
-const driver_error_descriptions = @compat Dict{Int,ASCIIString}(
+const driver_error_descriptions = @compat Dict{Int,String}(
         0 => "Success",
         1 => "Invalid value",
         2 => "Out of memory",

--- a/src/pointer.jl
+++ b/src/pointer.jl
@@ -36,7 +36,7 @@ function malloc(T::Type, n::Integer)
     rt.cudaMalloc(p, nbytes)
     cptr = CudaPtr(convert(Ptr{T},p[1]))
     finalizer(cptr, free)
-    cuda_ptrs[cptr] = device()
+    cuda_ptrs[WeakRef(cptr)] = device()
     cptr
 end
 malloc(nbytes::Integer) = malloc(Uint8, nbytes)

--- a/test/test.jl
+++ b/test/test.jl
@@ -32,7 +32,7 @@ result = CUDArt.devices(dev->CUDArt.capability(dev)[1] >= 2, nmax=1) do devlist
         @test typeof(g3) == AT{Int, 1}
         h2 = CUDArt.to_host(g2)
         @test typeof(h2) == Array{Int,1}
-        @test h2 == [1:5]
+        @test h2 == [1:5;]
         if AT == CUDArt.CudaPitchedArray
             p = pointer(g2)
             @test p.xsize == 5


### PR DESCRIPTION
Made cuda_ptrs use WeakRefs as keys.  Confirmed that this solves the gc() problem, thanks for the suggestion!  Although once in a while there are WeakRef(nothing)=>0 pairs left in cuda_ptrs (this happens intermittently, I can't reliably replicate it).  Other than that it passes the repo tests.  I also fixed a few minor problems that made the code more compatible with v0.4.
