### PR TITLE
Added /usr/local/cuda/lib path (standard OS X CUDA path)

### DIFF
--- a/src/CUDArt.jl
+++ b/src/CUDArt.jl
@@ -36,7 +36,7 @@ begin
 end
 : # linux or mac
 begin
-    const libcuda = Libdl.find_library(["libcuda"], ["/usr/lib/"])
+    const libcuda = Libdl.find_library(["libcuda"], ["/usr/lib/", "/usr/local/cuda/lib"])
 end)
 
 if isempty(libcuda)


### PR DESCRIPTION
This allows the package to load seamlessly on OS X with standard CUDA installation