### PR TITLE
Merge global `ptxdict` and `mdutils`.

### DIFF
--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -155,7 +155,7 @@ end
 
 function fill!{T}(X::CudaArray{T}, val; stream=null_stream)
     valT = convert(T, val)
-    func = ptxdict[device()][("fill_contiguous", T)]
+    func = ptxdict[device()].fns["fill_contiguous", T]
     nsm = attribute(device(), rt.cudaDevAttrMultiProcessorCount)
     mul = min(32, ceil(Int, length(X)/(256*nsm)))
     launch(func, mul*nsm, 256, (X, length(X), valT); stream=stream)
@@ -356,7 +356,7 @@ get!{T}(dst::CdArray{T}, src::AbstractCudaArray{T}, srcI::Tuple{Vararg{Union{Int
 
 function fill!{T}(X::CudaPitchedArray{T}, val; stream=null_stream)
     valT = convert(T, val)
-    func = ptxdict[device()][("fill_pitched", T)]
+    func = ptxdict[device()].fns["fill_pitched", T]
     nsm = attribute(device(), rt.cudaDevAttrMultiProcessorCount)
     mul = min(32, ceil(Int, length(X)/(256*nsm)))
     blockspergrid, threadsperblock = ndims(X) == 1 ? (mul*nsm, 256) : (mul*nsm, (16,16))

--- a/src/execute.jl
+++ b/src/execute.jl
@@ -32,7 +32,7 @@ end
 function cudasleep(secs; dev::Integer=device(), stream=null_stream)
     device(dev)
     rate = attribute(dev, rt.cudaDevAttrClockRate)
-    func = ptxdict[dev]["clock_block"]
+    func = ptxdict[dev].fns["clock_block"]
     twatchdog = 1.95  # watchdog timer kicks in after 2 secs
     while secs > 0
         tics = Int64(1000*rate*min(twatchdog, secs))  # rate is in kHz

--- a/test/test.jl
+++ b/test/test.jl
@@ -5,13 +5,10 @@ using Compat
 #########################
 # Device init and close #
 #########################
-@test length(CUDArt.mdutils) == 0
 @test length(CUDArt.ptxdict) == 0
 CUDArt.init(0)
-@test in(0, keys(CUDArt.mdutils))
 @test in(0, keys(CUDArt.ptxdict))
 CUDArt.close(0)
-@test length(CUDArt.mdutils) == 0
 @test length(CUDArt.ptxdict) == 0
 
 #########################


### PR DESCRIPTION
As discussed in #33

I decided to create an immutable for the dict's values instead of a tuple because the type got a bit unwieldy and I prefer the look of `ptxdict[dev].fns["clock_block"]` to `ptxdict[dev][1]["clock_block"]`.