### PR TITLE
Optionally check for devices that are not busy

### DIFF
--- a/src/execute.jl
+++ b/src/execute.jl
@@ -35,7 +35,7 @@ function cudasleep(secs; dev::Integer=device(), stream=null_stream)
     func = ptxdict[dev].fns["clock_block"]
     twatchdog = 1.95  # watchdog timer kicks in after 2 secs
     while secs > 0
-        tics = Int64(1000*rate*min(twatchdog, secs))  # rate is in kHz
+        tics = round(Int64, 1000*rate*min(twatchdog, secs))  # rate is in kHz
         secs -= twatchdog
         launch(func, 1, 1, (tics,), stream=stream)
     end


### PR DESCRIPTION
GPU memory is often in short supply, and so starting a job when something else is running can cause both jobs to fail. This PR enables one to optionally check whether other compute jobs are running on the device, and filter the device-list by the criterion that devices are unused.