### PR TITLE
Support element-type conversions in copy!

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia 0.4-
+julia 0.4

--- a/test/test.jl
+++ b/test/test.jl
@@ -75,6 +75,10 @@ result = CUDArt.devices(dev->CUDArt.capability(dev)[1] >= 2, nmax=1) do devlist
         fill!(gbig, -17)
         hbig = CUDArt.to_host(gbig)
         @test all(hbig .== -17) && size(hbig) == (2000,1000)
+        # Element-type conversions
+        h32 = rand(Float32, (5,3))
+        g64 = AT(Float64, (5,3))
+        copy!(g64, h32)
     end
     # Getting portions of an array
     h_src = reshape(1.0:15.0, 3, 5)


### PR DESCRIPTION
Previously, the host array had to have the same element type as the device array. This adds support for on-the-fly conversion, if you're copying from the host. One would have to write a kernel to implement `to_eltype` for device arrays; I don't currently have a need for that functionality, so presumably that can wait until someone needs it.