### PR TITLE
Fix and test cudasleep.

### DIFF
--- a/src/execute.jl
+++ b/src/execute.jl
@@ -7,6 +7,6 @@ function cudasleep(secs; dev::Integer=device(), stream=null_stream)
     while secs > 0
         tics = round(Int64, 1000*rate*min(twatchdog, secs))  # rate is in kHz
         secs -= twatchdog
-        cudacall(func, 1, 1, (Int64,), tics; stream=stream)
+        cudacall(func, 1, 1, (Int64,), tics; stream=convert(CuStream, stream))
     end
 end

--- a/test/test.jl
+++ b/test/test.jl
@@ -150,6 +150,8 @@ result = CUDArt.devices(dev->CUDArt.capability(dev)[1] >= 2, nmax=1) do devlist
     # Issue #41
     a = CUDArt.CudaArray(zeros(2))
     @test func41(a, (2,1,1,1)) == Cint[2,1,1,1]
+    # Comment in PR #50
+    CUDArt.cudasleep(1)
 end
 
 gc()  # check for finalizer errors


### PR DESCRIPTION
Streams need to be converted to CUDAdrv's object type. See https://github.com/JuliaGPU/CUDArt.jl/pull/50#issuecomment-238901450

cc @timholy 