### PR TITLE
README: link to CUDAdrv

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # CUDArt
 
-This is a wrapper of the CUDA Runtime API.
-It also implements some elements from the Driver API for working with CUDA modules and launching kernels.
-It borrows heavily from the [CUDA.jl](https://github.com/JuliaGPU/CUDA.jl) repository created by Dahua Lin.
+This package wraps the [CUDA runtime API](http://docs.nvidia.com/cuda/cuda-runtime-api/).
+For a wrapper of the lower-level [driver API](http://docs.nvidia.com/cuda/cuda-driver-api/),
+see [CUDAdrv](https://github.com/JuliaGPU/CUDAdrv.jl).
 
 # Platform support
 


### PR DESCRIPTION
I came across a confused @ChrisRackauckas on Gitter, so I decided to add a small blurb to [CUDAdrv](https://github.com/JuliaGPU/CUDAdrv.jl/commit/e87c6d4a7cb961e38f75f6e6b676bbdb25c7c569)/CUDArt/[CUDAnative](https://github.com/JuliaGPU/CUDAnative.jl/commit/df895e2d00976a90449a5dfb6232e4ead9e4731d) explaining the differences between our toolkit-wrapping packages.