### PR TITLE
Update for VS2015 support and get rid of view dep warn in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ see [CUDAdrv](https://github.com/JuliaGPU/CUDAdrv.jl).
 ## Platform support
 
 This has been tested on Linux, OSX, and Windows. With Windows, at least Visual Studio
-2010/2012/2013 are supported.
+2010/2012/2013/2015 are supported.
 
 
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.4
-Compat 0.7.20
+Compat 0.8.4
 CUDAdrv

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,14 +1,17 @@
 if is_windows()
-    if haskey(ENV, "VS120COMNTOOLS")
-        vs_cmd_prompt = string(ENV["VS120COMNTOOLS"], "..\\..\\VC\\vcvarsall.bat")
+    if haskey(ENV, "VS140COMNTOOLS")
+        vs_cmd_tools_dir = ENV["VS140COMNTOOLS"]
+    elseif haskey(ENV, "VS120COMNTOOLS")
+        vs_cmd_tools_dir = ENV["VS120COMNTOOLS"]
     elseif haskey(ENV, "VS110COMNTOOLS")
-        vs_cmd_prompt = string(ENV["VS110COMNTOOLS"], "..\\..\\VC\\vcvarsall.bat")
+        vs_cmd_tools_dir = ENV["VS110COMNTOOLS"]
     elseif haskey(ENV, "VS100COMNTOOLS")
-        vs_cmd_prompt = string(ENV["VS100COMNTOOLS"], "..\\..\\VC\\vcvarsall.bat")
+        vs_cmd_tools_dir = ENV["VS100COMNTOOLS"]
     else
-        error("Cannot find proper Visual Studio installation. VS 2013, 2012, or 2010 is required.")
+        error("Cannot find proper Visual Studio installation. VS 2015, 2013, 2012, or 2010 is required.")
     end
-
+    vs_cmd_prompt =joinpath(dirname(vs_cmd_tools_dir),"..","..","VC","vcvarsall.bat")
+    
     # check whether 32 or 64 bit archtecture
     # NOTE: Actually, nvcc in x86 visual studio command prompt doesn't make 32-bit binary
     #       It depends on whether CUDA toolkit is 32bit or 64bit

--- a/test/test.jl
+++ b/test/test.jl
@@ -1,5 +1,6 @@
 import CUDArt, CUDAdrv
 using Base.Test
+import Compat.view
 
 #########################
 # Device init and close #
@@ -80,7 +81,7 @@ result = CUDArt.devices(dev->CUDArt.capability(dev)[1] >= 2, nmax=1) do devlist
         g64 = AT(Float64, (5,3))
         copy!(g64, h32)
         # AbstractArray fallbacks
-        s32 = sub(h32, 5:-1:1, :)
+        s32 = view(h32, 5:-1:1, :)
         copy!(g64, s32)
     end
     # Getting portions of an array


### PR DESCRIPTION


Build successfully and passes tests  with v2015 and cuda8 and CUDArt.jl on master

```
Microsoft (R) Program Maintenance Utility Version 14.00.24210.0
Copyright (C) Microsoft Corporation.  All rights reserved.

        nvcc --shared --compiler-options="/wd4819" --linker-options= wrapcuda.c -o libwrapcuda.dll
nvcc warning : The 'compute_20', 'sm_20', and 'sm_21' architectures are deprecated, and may be removed in a future release (Use -Wno-deprecated-gpu-targets to suppress warning). wrapcuda.c
   Creating library libwrapcuda.lib and object libwrapcuda.exp
        nvcc -ptx --compiler-options="/wd4819" -gencode=arch=compute_20,code=sm_20 utils.cu
nvcc warning : The 'compute_20', 'sm_20', and 'sm_21' architectures are deprecated, and may be removed in a future release (Use -Wno-deprecated-gpu-targets to suppress warning). utils.cu

Microsoft (R) Program Maintenance Utility Version 14.00.24210.0
Copyright (C) Microsoft Corporation.  All rights reserved.

        nvcc -ptx --compiler-options="/wd4819" vadd.cu
nvcc warning : The 'compute_20', 'sm_20', and 'sm_21' architectures are deprecated, and may be removed in a future release (Use -Wno-deprecated-gpu-targets to suppress warning). vadd.cu

```
