### PR TITLE
Update for CUDAdrv from master.

### DIFF
--- a/src/device.jl
+++ b/src/device.jl
@@ -133,7 +133,7 @@ end
 function close(devlist::Union{Integer,AbstractVector})
     for dev in devlist
         if haskey(ptxdict, dev)
-            unload(ptxdict[dev].mod)
+            # CUDAdrv unloads the module using a finalizer
             delete!(ptxdict, dev)
         end
         device_reset(dev)

--- a/src/stream.jl
+++ b/src/stream.jl
@@ -16,7 +16,7 @@ function Stream()
     hnd = CuStream(p[1])
     Stream(hnd, Condition())
 end
-NullStream() = Stream(CuStream(C_NULL), Condition())
+NullStream() = Stream(CUDAdrv.CuDefaultStream(), Condition())
 
 convert(::Type{CuStream}, s::Stream) = s.inner
 


### PR DESCRIPTION
Updates for the new CUDAdrv now that it is compatible with julia 0.5 again (as of https://github.com/JuliaGPU/CUDAdrv.jl/commit/700ee90cb882a6d462539322da226345a400b82f).

Should not be merged before a new CUDAdrv.jl is tagged.

Also contains a bug, as CUDAdrv.jl now cleans up resources in a finalizer but CUDArt.jl seems to eagerly destroy certain linked resources (probably the `device_reset` in `device.jl::close`).