### PR TITLE
Fix the check for nvidia-smi

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -115,7 +115,7 @@ function find_nvml_smi()
         nvidiasmi = "nvidia-smi"
     end
     try
-        success(`nvidiadssmi`)
+        success(`$nvidiasmi`)
     catch
         nvidiasmi = ""
         warn("nvidia-smi failure")

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -114,9 +114,11 @@ function find_nvml_smi()
     else
         nvidiasmi = "nvidia-smi"
     end
-    if !success(`$nvidiasmi`)
-        warn("nvidia-smi failure")
+    try
+        success(`nvidiadssmi`)
+    catch
         nvidiasmi = ""
+        warn("nvidia-smi failure")
     end
 
     if isempty(nvidiasmi) && isempty(libnvml)


### PR DESCRIPTION
If nvidia-smi does not exist, i.e. if the process cannot be strated, we should not throw an error since there is the libnvml fallback.