### PR TITLE
Work around Mac OSX missing nvidia-smi

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -121,12 +121,16 @@ function find_nvml_smi()
             nvidiasmi = ""
         end
     catch err
-        warn("Encountered $err while executing `nvidia-smi`")
+        warn("Encountered error \"$err\" while executing `nvidia-smi`")
         nvidiasmi = ""
     end
 
     if isempty(nvidiasmi) && isempty(libnvml)
-        error("NVML nor nvidia-smi can be found.")
+        if is_apple()
+            warn("NVML nor nvidia-smi can be found.")
+        else
+            error("NVML nor nvidia-smi can be found.")
+        end
     end
 
     libnvml, nvidiasmi

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -114,11 +114,15 @@ function find_nvml_smi()
     else
         nvidiasmi = "nvidia-smi"
     end
+
     try
-        success(`$nvidiasmi`)
-    catch
+        if !success(`$nvidiasmi`)
+            warn("nvidia-smi failure")
+            nvidiasmi = ""
+        end
+    catch err
+        warn("Encountered $err while executing `nvidia-smi`")
         nvidiasmi = ""
-        warn("nvidia-smi failure")
     end
 
     if isempty(nvidiasmi) && isempty(libnvml)

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -114,9 +114,11 @@ function find_nvml_smi()
     else
         nvidiasmi = "nvidia-smi"
     end
-    if !success(`$nvidiasmi`)
-        warn("nvidia-smi failure")
+    try
+        success(`$nvidiasmi`)
+    catch
         nvidiasmi = ""
+        warn("nvidia-smi failure")
     end
 
     if isempty(nvidiasmi) && isempty(libnvml)

--- a/src/device.jl
+++ b/src/device.jl
@@ -103,6 +103,14 @@ function filter_free(devlist)
         end
         ccall(("nvmlShutdown", libnvml), UInt32, ())
         return freelist
+    elseif isempty(nvidia_smi)
+        Base.warn_once(
+        """
+        Neither NVML nor nvidia-smi are available.
+        Please check your setup and install either one.
+        `CUDArt.filter_free` will not work.
+        """)
+        return devlist
     else
         smi = readstring(`$nvidia_smi`)
         if contains(smi, "No running")


### PR DESCRIPTION
Supersedes #84 and fixes #83.

@dlfivefifty, can you give this a go? I had to disable a feature but it should make CUDArt usable in situations where nvidia-smi is not available.