### PR TITLE
Begin deprecation process

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+### Note: This package is being phased out.
+
+Please use [CUDAdrv](https://github.com/JuliaGPU/CUDAdrv.jl) to interact with CUDA from Julia.
+
 # CUDArt
 
 **Build status**: [![][buildbot-julia05-img]][buildbot-julia05-url] [![][buildbot-julia06-img]][buildbot-julia06-url]


### PR DESCRIPTION
CUDArt is fairly out of date, and duplicates a lot of CUDAdrv functionality in an incompatible way. We've discussed standardising on CUDAdrv, and if people need higher-level functionality it's easy to add it there.